### PR TITLE
Removed yast2-registration and yast2-caasp dependencies

### DIFF
--- a/control/control.Kubic.xml
+++ b/control/control.Kubic.xml
@@ -621,7 +621,6 @@ textdomain="control"
         <clone_module>kdump</clone_module>
         <clone_module>ntp-client</clone_module>
         <clone_module>ssh_import</clone_module>
-        <clone_module>scc</clone_module>
     </clone_modules>
 
     <texts>

--- a/package/skelcd-control-Kubic.changes
+++ b/package/skelcd-control-Kubic.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jun 20 11:43:19 UTC 2018 - lslezak@suse.cz
+
+- yast2-registration and yast2-caasp are not used in openSUSE
+  Kubic, remove the dependencies (also fixes the build on i586
+  where these packages are not available)
+- 15.1.0
+
+-------------------------------------------------------------------
 Thu Jun 14 09:26:12 UTC 2018 - rbrown@suse.com
 
 - Start chronyd on Admin System Role (boo#1097625)

--- a/package/skelcd-control-Kubic.spec
+++ b/package/skelcd-control-Kubic.spec
@@ -49,16 +49,13 @@ BuildRequires:  skelcd-control-openSUSE
 
 # SLES specific Yast packages needed in the inst-sys
 # to provide the functionality needed by this control file
-Requires:       yast2-registration
+
 %if 0%{?is_susecaasp}
 Requires:       yast2-theme-SLE
 %else
 Requires:       yast2-branding-openSUSE
 Requires:       yast2-qt-branding-openSUSE
 %endif
-
-# the CaaSP specific packages
-Requires:       yast2-caasp
 
 # Generic Yast packages needed for the installer
 Requires:       autoyast2
@@ -111,7 +108,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-Kubic
 AutoReqProv:    off
-Version:        15.0.14
+Version:        15.1.0
 Release:        0
 Summary:        The Kubic control file needed for installation
 License:        MIT


### PR DESCRIPTION
- 15.1.0

Fixes installation problem:
```
can't install skelcd-control-Kubic-15.0.14-1.1.i586:
  nothing provides yast2-registration needed by skelcd-control-Kubic-15.0.14-1.1.i586
  nothing provides yast2-caasp needed by skelcd-control-Kubic-15.0.14-1.1.i586
```

The yast2-registration package is not available on i586 due to the SUSEConnect limitations.

However, it turned out that the registration and the all-in-one CAASP installation dialog is not used in openSUSE Kubic show we can remove these dependencies completely.