### PR TITLE
Display additional configuration dialog for the "kubeadm" role (FATE#325834)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/package/*.tar.bz2
+doc/
+.yardoc/
+control.pot

--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+set -e -x
+
+make -C control check
+
+# the "yast-travis-ruby" script is included in the base yastdevel/ruby image
+# see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
+yast-travis-ruby
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: required
+language: bash
+services:
+  - docker
+
+before_install:
+  - docker build -t yast-skelcd-control-kubic-image .
+script:
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-skelcd-control-kubic-image ./.travis.sh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 skelcd-control-Kubic
 ===================
 
-[![Travis Build](https://travis-ci.org/yast/skelcd-control-Kubic.svg?branch=master)](https://travis-ci.org/yast/skelcd-control-CAASP)
+[![Travis Build](https://travis-ci.org/yast/skelcd-control-Kubic.svg?branch=master)](https://travis-ci.org/yast/skelcd-control-Kubic)
 
 
 Installation control file for openSUSE Kubic

--- a/control/control.Kubic.xml
+++ b/control/control.Kubic.xml
@@ -250,6 +250,7 @@ textdomain="control"
         </software>
 
         <order config:type="integer">200</order>
+        <additional_dialogs>inst_kubic_kubeadm_role</additional_dialogs>
       </system_role>
 
       <system_role>

--- a/package/skelcd-control-Kubic.changes
+++ b/package/skelcd-control-Kubic.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Fri Oct 26 15:36:28 UTC 2018 - lslezak@suse.cz
+
+- Display a new dialog when selecting the Kubeadm role
+  (FATE#325834)
+- Removed the SLE/CaaSP handling, this is just an openSUSE package
+- Use %license for the license file
+- 15.1.7
+
+-------------------------------------------------------------------
 Tue Aug 21 15:32:55 UTC 2018 - rbrown@suse.com
 
 - Run partition proposal before bootloader proposal (boo#1099762)

--- a/package/skelcd-control-Kubic.spec
+++ b/package/skelcd-control-Kubic.spec
@@ -33,13 +33,11 @@ BuildRequires:  libxml2-tools
 # RNG validation schema
 BuildRequires:  yast2-installation-control >= 4.0.10
 
-%if 0%{?is_opensuse}
 # xsltproc - for building control.TWKubic.xml from control.Kubic.xml
 BuildRequires:  libxslt-tools
 BuildRequires:  diffutils
 # we need to copy some parts from the openSUSE control.xml to Kubic
 BuildRequires:  skelcd-control-openSUSE
-%endif
 
 ######################################################################
 #
@@ -47,15 +45,13 @@ BuildRequires:  skelcd-control-openSUSE
 # installation system (inst-sys) for the Yast installer
 #
 
-# SLES specific Yast packages needed in the inst-sys
+# Kubic specific Yast packages needed in the inst-sys
 # to provide the functionality needed by this control file
+Requires:       yast2-caasp >= 4.1.1
 
-%if 0%{?is_susecaasp}
-Requires:       yast2-theme-SLE
-%else
+# branding
 Requires:       yast2-branding-openSUSE
 Requires:       yast2-qt-branding-openSUSE
-%endif
 
 # Generic Yast packages needed for the installer
 Requires:       autoyast2
@@ -92,6 +88,23 @@ Requires:       yast2-rdp
 Conflicts:      product_control
 Provides:       product_control
 
+# we really do not need the YaST packages for building, ignore the dependencies
+# to have faster builds and less rebuilds triggered by dependencies
+# these are pulled in by the skelcd-control-openSUSE dependencies
+#!BuildIgnore: yast2-caasp yast2-branding-openSUSE yast2-qt-branding-openSUSE
+#!BuildIgnore: autoyast2 yast2-add-on yast2-buildtools yast2-devtools
+#!BuildIgnore: yast2-fcoe-client yast2-firewall
+#!BuildIgnore: yast2-installation yast2-iscsi-client yast2-kdump yast2-multipath
+#!BuildIgnore: yast2-network yast2-nfs-client yast2-ntp-client yast2-proxy
+#!BuildIgnore: yast2-services-manager yast2-slp yast2-trans-stats yast2-tune
+#!BuildIgnore: yast2-update yast2-users yast2-x11 yast2-rdp
+#!BuildIgnore: yast2-reipl yast2-s390 yast2-vm
+#!BuildIgnore: rubygem(%{rb_default_ruby_abi}:byebug)
+#!BuildIgnore: yast2-branding-openSUSE-Oxygen yast2-configuration-management
+#!BuildIgnore: yast2-core yast2-hardware-detection yast2-installation-control
+#!BuildIgnore: yast2-logs yast2-perl-bindings yast2-pkg-bindings yast2-ruby-bindings
+#!BuildIgnore: yast2 yast2-ycp-ui-bindings
+
 # Architecture specific packages
 #
 %ifarch s390 s390x
@@ -108,7 +121,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-Kubic
 AutoReqProv:    off
-Version:        15.1.6
+Version:        15.1.7
 Release:        0
 Summary:        The Kubic control file needed for installation
 License:        MIT
@@ -127,14 +140,12 @@ The package contains the Kubic control file needed for installation.
 
 %setup -n %{name}-%{version}
 
-%if 0%{?is_opensuse}
 %build
 # build control.TWKubic.xml from control.Kubic.xml
 make -C control control.TWKubic.xml
 # display the changes (just for easier debugging)
 # don't fail, a difference is expected
 diff -u control/control.Kubic.xml control/control.TWKubic.xml || :
-%endif
 
 %check
 #
@@ -147,14 +158,7 @@ make -C control check
 # Add control file
 #
 mkdir -p $RPM_BUILD_ROOT%{?skelcdpath}/CD1
-%if 0%{?is_susecaasp}
-install -m 644 control/control.CAASP.xml $RPM_BUILD_ROOT%{?skelcdpath}/CD1/control.xml
-%else
-%if 0%{?is_opensuse}
 install -m 644 control/control.TWKubic.xml $RPM_BUILD_ROOT%{?skelcdpath}/CD1/control.xml
-%endif
-%endif
-
 
 # install LICENSE (required by build service check)
 mkdir -p $RPM_BUILD_ROOT/%{_prefix}/share/doc/packages/%{name}
@@ -162,14 +166,12 @@ install -m 644 LICENSE $RPM_BUILD_ROOT/%{_prefix}/share/doc/packages/%{name}
 
 %files
 %defattr(644,root,root,755)
-%if 0%{?is_susecaasp}%{?is_opensuse}
 %if %{defined skelcdpath}
 %dir %{skelcdpath}
 %endif
 %dir %{?skelcdpath}/CD1
 %{?skelcdpath}/CD1/control.xml
-%endif
 %doc %dir %{_prefix}/share/doc/packages/%{name}
-%doc %{_prefix}/share/doc/packages/%{name}/LICENSE
+%license %{_prefix}/share/doc/packages/%{name}/LICENSE
 
 %changelog


### PR DESCRIPTION
## Summary

#### The Main Change
- Display extra NTP configuration dialog when selecting the "kubeadm Node" role, then the standard root password dialog follows
- https://en.opensuse.org/Kubic:CaaSPInstallationComparision#Combined_Workflow
- https://fate.suse.com/325834

#### Additional Changes

- The NTP servers are proposed from the DHCP response
- Added Travis support back
- CaaSP cleanup, this package has been split off from the skelcd-control-CAASP and is not included in SLE so we can remove all that CaaSP vs. Kubic conditions
- With the added `BuildIgnore` tags the build dependency chain decreased from 314 to 127 packages (faster rebuild, less rebuilds in OBS triggered by the dependencies)
- Use `%license` tag for the `LICENSE` file

## Screencast

![kubic_kubeadm_role_dialog](https://user-images.githubusercontent.com/907998/47410748-0a58df80-d767-11e8-8258-9f595a5f31d8.gif)
