### PR TITLE
Use the *.opensuse.pool.ntp.org fallback (bsc#1114818)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,31 @@ Yast::Tasks.configuration do |conf|
   #lets ignore license check for now
   conf.skip_license_check << /.*/
 end
+
+# this package uses the date versioning in master (for openSUSE Tumbleweed),
+# replace the standard yast task implementation
+Rake::Task[:'version:bump'].clear
+namespace :version do
+  desc "Update version in the package/skelcd-control-Kubic.spec file"
+  task :bump do
+    spec_file = "package/skelcd-control-Kubic.spec"
+    spec = File.read(spec_file)
+
+    # parse the current version, it can be in <date> or <date>.<release> format
+    _, version, release = spec.match(/^\s*Version:\s*(\w+)(?:\.(\w+))?$/).to_a
+    # use the UTC time to avoid conflicts when updating from different time zones
+    date = Time.now.utc.strftime("%Y%m%d")
+
+    # add a release version if the package has been already updated today
+    new_version = if version == date
+      # if the release was missing it starts from 1
+      "#{date}.#{release.to_i + 1}"
+    else
+      "#{date}"
+    end
+
+    puts "Updating to #{new_version}"
+    spec.gsub!(/^\s*Version:.*$/, "Version:        #{new_version}")
+    File.write(spec_file, spec)
+  end
+end

--- a/control/control.Kubic.xml
+++ b/control/control.Kubic.xml
@@ -63,8 +63,8 @@ textdomain="control"
         <!-- FATE: #303893: Default to enabled kdump -->
         <enable_kdump config:type="boolean">true</enable_kdump>
 
-        <!-- bnc #431259 -->
-        <default_ntp_setup config:type="boolean">false</default_ntp_setup>
+        <!-- use *.opensuse.pool.ntp.org fallback when an NTP server is not set in the DHCP response -->
+        <default_ntp_setup config:type="boolean">true</default_ntp_setup>
 
         <!-- bnc #431158: Adjusts /etc/sysconfig/security/POLKIT_DEFAULT_PRIVS if set -->
         <polkit_default_privs>restrictive</polkit_default_privs>

--- a/package/skelcd-control-Kubic.changes
+++ b/package/skelcd-control-Kubic.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Nov 14 08:08:36 UTC 2018 - lslezak@suse.cz
+
+- Use the *.opensuse.pool.ntp.org fallback when an NTP server
+  is not set in the DHCP response (bsc#1114818)
+- Use a date based versioning (the Leap schema does not make sense
+  for the Tumbleweed based Kubic)
+- version 20181114
+
+-------------------------------------------------------------------
 Fri Oct 26 15:36:28 UTC 2018 - lslezak@suse.cz
 
 - Display a new dialog when selecting the Kubeadm role

--- a/package/skelcd-control-Kubic.spec
+++ b/package/skelcd-control-Kubic.spec
@@ -121,7 +121,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-Kubic
 AutoReqProv:    off
-Version:        15.1.7
+Version:        20181114
 Release:        0
 Summary:        The Kubic control file needed for installation
 License:        MIT


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1114818
- Use the `*.opensuse.pool.ntp.org` fallback when an NTP server is not set in the DHCP response
- Use a date based versioning (the Leap schema does not make sense for the Tumbleweed based Kubic)
- This is the same change as in https://github.com/yast/skelcd-control-openSUSE/pull/150
