### PR TITLE
Fit microOS on 20GB disks, kubeadm on 30GB (boo#1119288)

### DIFF
--- a/control/control.Kubic.xml
+++ b/control/control.Kubic.xml
@@ -143,9 +143,9 @@ textdomain="control"
                 <mount_point>/</mount_point>
                 <!-- Default == final, since the user can't change it -->
                 <fs_type>btrfs</fs_type>
-                <desired_size config:type="disksize">25 GiB</desired_size>
-                <min_size config:type="disksize">20 GiB</min_size>
-                <max_size config:type="disksize">30 GiB</max_size>
+                <desired_size config:type="disksize">20 GiB</desired_size>
+                <min_size config:type="disksize">11 GiB</min_size>
+                <max_size config:type="disksize">40 GiB</max_size>
                 <weight config:type="integer">20</weight>
                 <!-- Always use snapshots, no matter what -->
                 <snapshots config:type="boolean">true</snapshots>
@@ -209,7 +209,7 @@ textdomain="control"
                 <snapshots config:type="boolean">false</snapshots>
                 <snapshots_configurable config:type="boolean">false</snapshots_configurable>
 
-                <desired_size config:type="disksize">15 GiB</desired_size>
+                <desired_size config:type="disksize">19 GiB</desired_size>
                 <min_size config:type="disksize">8 GiB</min_size>
                 <max_size config:type="disksize">unlimited</max_size>
                 <weight config:type="integer">40</weight>
@@ -245,6 +245,107 @@ textdomain="control"
         <software>
             <default_patterns>SUSE-MicroOS SUSE-MicroOS-hardware SUSE-MicroOS-apparmor kubeadm SUSE-MicroOS-container-runtime</default_patterns>
         </software>
+
+        <partitioning>
+          <expert_partitioner_warning config:type="boolean">true</expert_partitioner_warning>
+
+          <proposal>
+              <lvm config:type="boolean">false</lvm>
+              <proposal_settings_editable config:type="boolean">true</proposal_settings_editable>
+              <windows_delete_mode config:type="symbol">all</windows_delete_mode>
+              <linux_delete_mode config:type="symbol">all</linux_delete_mode>
+              <other_delete_mode config:type="symbol">all</other_delete_mode>
+          </proposal>
+
+          <volumes config:type="list">
+              <!-- The / filesystem -->
+              <volume>
+                  <mount_point>/</mount_point>
+                  <!-- Default == final, since the user can't change it -->
+                  <fs_type>btrfs</fs_type>
+                  <desired_size config:type="disksize">20 GiB</desired_size>
+                  <min_size config:type="disksize">20 GiB</min_size>
+                  <max_size config:type="disksize">40 GiB</max_size>
+                  <weight config:type="integer">20</weight>
+                  <!-- Always use snapshots, no matter what -->
+                  <snapshots config:type="boolean">true</snapshots>
+                  <snapshots_configurable config:type="boolean">false</snapshots_configurable>
+
+                  <!-- You don't want to miss the / volume -->
+                  <proposed_configurable config:type="boolean">false</proposed_configurable>
+
+                  <!-- the default subvolume "@" was requested by product management -->
+                  <btrfs_default_subvolume>@</btrfs_default_subvolume>
+                  <!-- root filesystem should be read-only -->
+                  <btrfs_read_only config:type="boolean">true</btrfs_read_only>
+
+                  <!-- Subvolumes to be created for a Btrfs root file system -->
+                  <!-- copy_on_write is true by default -->
+                  <!-- The XML parser is very simplistic, thus not using attributes, but sub-elements -->
+                  <subvolumes config:type="list">
+                      <subvolume>
+                          <path>root</path>
+                      </subvolume>
+                      <subvolume>
+                          <path>tmp</path>
+                      </subvolume>
+                      <subvolume>
+                          <path>home</path>
+                      </subvolume>
+                      <subvolume>
+                          <path>opt</path>
+                      </subvolume>
+
+                      <!-- architecture specific subvolumes -->
+
+                      <subvolume>
+                          <path>boot/grub2/arm64-efi</path>
+                          <archs>aarch64</archs>
+                      </subvolume>
+                      <subvolume>
+                          <path>boot/grub2/i386-pc</path>
+                          <archs>x86_64</archs>
+                      </subvolume>
+                      <subvolume>
+                          <path>boot/grub2/powerpc-ieee1275</path>
+                          <archs>ppc,!board_powernv</archs>
+                      </subvolume>
+                      <subvolume>
+                          <path>boot/grub2/s390x-emu</path>
+                          <archs>s390</archs>
+                      </subvolume>
+                      <subvolume>
+                          <path>boot/grub2/x86_64-efi</path>
+                          <archs>x86_64</archs>
+                      </subvolume>
+                  </subvolumes>
+              </volume>
+
+              <volume>
+                  <!-- unified var partition - https://lists.opensuse.org/opensuse-packaging/2017-11/msg00017.html -->
+                  <mount_point>/var</mount_point>
+                  <!-- Default == final, since the user can't change it -->
+                  <fs_type>btrfs</fs_type>
+                  <snapshots config:type="boolean">false</snapshots>
+                  <snapshots_configurable config:type="boolean">false</snapshots_configurable>
+
+                  <desired_size config:type="disksize">19 GiB</desired_size>
+                  <min_size config:type="disksize">8 GiB</min_size>
+                  <max_size config:type="disksize">unlimited</max_size>
+                  <weight config:type="integer">40</weight>
+
+                  <!-- Give up in a separate partition if the min size doesn't fit -->
+                  <disable_order config:type="integer">1</disable_order>
+
+                  <!-- If this volume is disabled, we want "/" to increase -->
+                  <fallback_for_desired_size>/</fallback_for_desired_size>
+                  <fallback_for_max_size>/</fallback_for_max_size>
+                  <fallback_for_weight>/</fallback_for_weight>
+              </volume>
+
+              <!-- No swap partition is defined, so it's never created -->
+          </volumes>
+        </partitioning>
 
         <order config:type="integer">200</order>
         <additional_dialogs>inst_kubic_kubeadm_role</additional_dialogs>

--- a/package/skelcd-control-Kubic.changes
+++ b/package/skelcd-control-Kubic.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jan 08 16:57:53 UTC 2019 - Richard Brown <rbrown@suse.de>
+
+- Fit microOS on 20GB disks, kubeadm on 30GB (boo#1119288)
+- 20190108
+
+-------------------------------------------------------------------
 Tue Dec 11 15:46:13 UTC 2018 - Richard Brown <rbrown@suse.de>
 
 - Add container-runtime-config pattern to MicroOS role (boo#1119153)

--- a/package/skelcd-control-Kubic.spec
+++ b/package/skelcd-control-Kubic.spec
@@ -121,7 +121,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-Kubic
 AutoReqProv:    off
-Version:        20181211
+Version:        20190108
 Release:        0
 Summary:        The Kubic control file needed for installation
 License:        MIT


### PR DESCRIPTION
As in $subject, this SR changes the partitioning for Kubic to fit on smaller disks