### PR TITLE
Don't show addons by default

### DIFF
--- a/control/control.Kubic.xml
+++ b/control/control.Kubic.xml
@@ -44,7 +44,7 @@ textdomain="control"
 
         <!-- Offer add-ons in the installation -->
         <show_addons config:type="boolean">true</show_addons>
-        <addons_default config:type="boolean">true</addons_default>
+        <addons_default config:type="boolean">false</addons_default>
 
         <!-- FATE #301937, Save /root content from the installation system to the installed system -->
         <save_instsys_content config:type="list">

--- a/package/skelcd-control-Kubic.changes
+++ b/package/skelcd-control-Kubic.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 06 09:36:35 UTC 2019 - Richard Brown <rbrown@suse.de>
+
+- Don't show addon step by default (boo#1123481)
+- 20190206
+
+-------------------------------------------------------------------
 Tue Jan 29 10:40:11 UTC 2019 - Richard Brown <rbrown@suse.de>
 
 - Add support for additional repos with addon= (boo#1123481)

--- a/package/skelcd-control-Kubic.spec
+++ b/package/skelcd-control-Kubic.spec
@@ -121,7 +121,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-Kubic
 AutoReqProv:    off
-Version:        20190129
+Version:        20190206
 Release:        0
 Summary:        The Kubic control file needed for installation
 License:        MIT


### PR DESCRIPTION
It would be really nice if the function of <addons_default> was documented somewhere..I can't find it no matter how hard I search ;)