### PR TITLE
Kubic changes for boo#1125949

### DIFF
--- a/control/control.Kubic.xml
+++ b/control/control.Kubic.xml
@@ -109,7 +109,7 @@ textdomain="control"
         <!-- bnc#875350: Explicitly selecting these patterns by default -->
         <!-- For a list of patterns, see https://build.suse.de/package/view_file/SUSE:SLE-12-SP2:Update:Products:CASP10/patterns-caasp/patterns-caasp.spec?expand=1 -->
 
-        <default_patterns>SUSE-MicroOS SUSE-MicroOS-hardware SUSE-MicroOS-apparmor SUSE-MicroOS-container-runtime SUSE-MicroOS-container-runtime-config SUSE-MicroOS-alt-container-runtime</default_patterns>
+        <default_patterns>SUSE-MicroOS SUSE-MicroOS-hardware SUSE-MicroOS-apparmor SUSE-MicroOS-container-runtime</default_patterns>
         <!-- bnc#876760: Explicitly selecting these (optional) patterns by default if they exist -->
         <optional_default_patterns>32bit</optional_default_patterns>
 
@@ -243,7 +243,7 @@ textdomain="control"
         </services>
 
         <software>
-            <default_patterns>SUSE-MicroOS SUSE-MicroOS-hardware SUSE-MicroOS-apparmor kubeadm SUSE-MicroOS-container-runtime</default_patterns>
+            <default_patterns>SUSE-MicroOS SUSE-MicroOS-hardware SUSE-MicroOS-apparmor kubeadm SUSE-MicroOS-container-runtime-kubernetes</default_patterns>
         </software>
 
         <partitioning>
@@ -438,8 +438,7 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
         </micro_os_role>
         <micro_os_role_description>
 	<label>• System designed for running containers and optimised for large deployments.
-• Includes CRI-O Container Runtime by default
-• Also includes Docker Open Source Container Runtime as an alternative</label>
+• Includes Podman Container Runtime by default</label>
         </micro_os_role_description>
     </texts>
 

--- a/package/skelcd-control-Kubic.changes
+++ b/package/skelcd-control-Kubic.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue Feb 19 14:06:11 UTC 2019 - Richard Brown <rbrown@suse.de>
+
+- Remove docker from MicroOS System Role
+- Use new container-runtime-kubernetes pattern in kubeadm role
+- Correct role descriptions
+- [boo#1125949]
+- 20190219
+
+-------------------------------------------------------------------
 Wed Feb 06 09:36:35 UTC 2019 - Richard Brown <rbrown@suse.de>
 
 - Don't show addon step by default (boo#1123481)

--- a/package/skelcd-control-Kubic.spec
+++ b/package/skelcd-control-Kubic.spec
@@ -121,7 +121,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-Kubic
 AutoReqProv:    off
-Version:        20190206
+Version:        20190219
 Release:        0
 Summary:        The Kubic control file needed for installation
 License:        MIT


### PR DESCRIPTION
As explained in https://bugzilla.opensuse.org/show_bug.cgi?id=1125949 we're shifting a lot around when it comes to Kubic and it's container runtimes. This means shifting patterns around and their names, hence these skelcd changes