### PR TITLE
Use new patterns-microos pattern names

### DIFF
--- a/control/control.Kubic.xml
+++ b/control/control.Kubic.xml
@@ -110,7 +110,7 @@ textdomain="control"
         <!-- bnc#875350: Explicitly selecting these patterns by default -->
         <!-- For a list of patterns, see https://build.suse.de/package/view_file/SUSE:SLE-12-SP2:Update:Products:CASP10/patterns-caasp/patterns-caasp.spec?expand=1 -->
 
-        <default_patterns>SUSE-MicroOS SUSE-MicroOS-defaults SUSE-MicroOS-hardware SUSE-MicroOS-apparmor SUSE-MicroOS-container-runtime</default_patterns>
+        <default_patterns>microos_base microos_defaults microos_hardware microos_apparmor container_runtime</default_patterns>
         <!-- bnc#876760: Explicitly selecting these (optional) patterns by default if they exist -->
         <optional_default_patterns>32bit</optional_default_patterns>
 
@@ -244,7 +244,7 @@ textdomain="control"
         </services>
 
         <software>
-            <default_patterns>SUSE-MicroOS SUSE-MicroOS-defaults SUSE-MicroOS-hardware SUSE-MicroOS-apparmor kubeadm SUSE-MicroOS-container-runtime-kubernetes</default_patterns>
+            <default_patterns>microos microos_defaults microos_hardware microos_apparmor kubeadm container_runtime_kubernetes</default_patterns>
         </software>
 
         <partitioning>

--- a/package/skelcd-control-Kubic.changes
+++ b/package/skelcd-control-Kubic.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Apr 05 12:47:11 UTC 2019 - Richard Brown <rbrown@suse.de>
+
+- Use new patterns-microos pattern names
+- 20190405
+
+-------------------------------------------------------------------
 Fri Mar 15 15:36:31 UTC 2019 - David Díaz <dgonzalez@suse.com>
 
 - Set language as readonly (bsc#1121256)

--- a/package/skelcd-control-Kubic.spec
+++ b/package/skelcd-control-Kubic.spec
@@ -121,7 +121,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-Kubic
 AutoReqProv:    off
-Version:        20190315
+Version:        20190405
 Release:        0
 Summary:        The Kubic control file needed for installation
 License:        MIT


### PR DESCRIPTION
patterns-caasp is getting dropped, so we need to use the new patterns-microos pattern names to get Kubic through staging:H