### PR TITLE
Set package manager patterns for Kubic roles (boo#1182803, boo#1183231)

### DIFF
--- a/control/control.Kubic.xml
+++ b/control/control.Kubic.xml
@@ -83,7 +83,7 @@ textdomain="control"
 
         <selection_type config:type="symbol">auto</selection_type>
 
-        <default_patterns>microos_base microos_defaults microos_hardware microos_apparmor container_runtime</default_patterns>
+        <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware microos_apparmor container_runtime</default_patterns>
         <!-- bnc#876760: Explicitly selecting these (optional) patterns by default if they exist -->
         <optional_default_patterns>32bit</optional_default_patterns>
 
@@ -228,7 +228,7 @@ textdomain="control"
         </services>
 
         <software>
-            <default_patterns>microos_base microos_defaults microos_hardware microos_apparmor kubic_admin</default_patterns>
+            <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware microos_apparmor kubic_admin</default_patterns>
         </software>
 
         <order config:type="integer">110</order>
@@ -243,7 +243,7 @@ textdomain="control"
         </services>
 
         <software>
-            <default_patterns>microos_base microos_defaults microos_hardware microos_apparmor kubic_worker</default_patterns>
+            <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware microos_apparmor kubic_worker</default_patterns>
         </software>
 
         <order config:type="integer">120</order>
@@ -254,7 +254,7 @@ textdomain="control"
         <id>kubic_lb_role</id>
 
         <software>
-            <default_patterns>microos_base microos_defaults microos_hardware microos_apparmor kubic_loadbalancer</default_patterns>
+            <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware microos_apparmor kubic_loadbalancer</default_patterns>
         </software>
 
         <order config:type="integer">130</order>
@@ -269,7 +269,7 @@ textdomain="control"
         </services>
 
         <software>
-            <default_patterns>microos_base microos_defaults microos_hardware microos_apparmor kubeadm container_runtime_kubernetes</default_patterns>
+            <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware microos_apparmor kubeadm container_runtime_kubernetes</default_patterns>
         </software>
 
         <order config:type="integer">200</order>

--- a/package/skelcd-control-Kubic.changes
+++ b/package/skelcd-control-Kubic.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar  9 08:21:56 EST 2021 - Neal Gompa <ngompa13@gmail.com>
+
+- Set package manager patterns for Kubic roles (boo#1182803, boo#1183231)
+- 20210308
+
+-------------------------------------------------------------------
 Tue Nov 17 17:00:10 CEST 2020 - Richard Brown <rbrown@suse.de>
 
 - Normalise & correct minimum partition requirements (boo#1178895)

--- a/package/skelcd-control-Kubic.spec
+++ b/package/skelcd-control-Kubic.spec
@@ -121,7 +121,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-Kubic
 AutoReqProv:    off
-Version:        20201117
+Version:        20210308
 Release:        0
 Summary:        The Kubic control file needed for installation
 License:        MIT


### PR DESCRIPTION
The openSUSE MicroOS patterns are getting split up to support
building MicroOS systems using either transactional-update (Zypper),
Micro DNF (with txnupd plugin), or PackageKit (with txnupd plugin).

Resolves: [boo#1183231](https://bugzilla.opensuse.org/show_bug.cgi?id=1183231)