### PR TITLE
Define default NTP servers (bsc#1180699)

### DIFF
--- a/control/control.Kubic.xml
+++ b/control/control.Kubic.xml
@@ -47,6 +47,14 @@ textdomain="control"
         <show_addons config:type="boolean">true</show_addons>
         <addons_default config:type="boolean">false</addons_default>
 
+        <!-- #1180699: Use openSUSE default NTP servers instead of SUSE ones -->
+        <default_ntp_servers config:type="list">
+          <ntp_server>0.opensuse.pool.ntp.org</ntp_server>
+          <ntp_server>1.opensuse.pool.ntp.org</ntp_server>
+          <ntp_server>2.opensuse.pool.ntp.org</ntp_server>
+          <ntp_server>3.opensuse.pool.ntp.org</ntp_server>
+        </default_ntp_servers>
+
         <!-- casp require precise time for its work -->
         <precise_time config:type="boolean">true</precise_time>
 

--- a/package/skelcd-control-Kubic.changes
+++ b/package/skelcd-control-Kubic.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Sep  7 10:49:43 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Define default NTP servers for Kubic (bsc#1180699)
+- 20210907
+
+-------------------------------------------------------------------
 Wed Jun  2 13:25:34 UTC 2021 - Stefan Schubert <schubi@suse.de>
 
 - Enable ipv4_forward and ipv6_forward for ALL roles (bsc#1186280).

--- a/package/skelcd-control-Kubic.spec
+++ b/package/skelcd-control-Kubic.spec
@@ -31,7 +31,7 @@ Name:           skelcd-control-Kubic
 # xmllint (for validation)
 BuildRequires:  libxml2-tools
 # RNG validation schema
-BuildRequires:  yast2-installation-control >= 4.4.2
+BuildRequires:  yast2-installation-control >= 4.4.3
 
 # xsltproc - for building control.TWKubic.xml from control.Kubic.xml
 BuildRequires:  libxslt-tools
@@ -121,7 +121,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-Kubic
 AutoReqProv:    off
-Version:        20210531
+Version:        20210907
 Release:        0
 Summary:        The Kubic control file needed for installation
 License:        MIT


### PR DESCRIPTION
## Problem

By default the proposed **NTP** servers are choosing the servers based on the product name, but this detection is currently broken and **SUSE** servers are used instead of **openSUSE** ones. Thus, it has been requested to be able to define the default servers in the control file, something already implemented by (https://github.com/yast/yast-installation-control/pull/105 and https://github.com/yast/yast-network/pull/1246).

- https://trello.com/c/HtBLfvR0/4499-ostumbleweed-p5-1180699-microos-defaults-to-using-the-suse-ntp-pool
- https://bugzilla.suse.com/show_bug.cgi?id=1180699

## Solution

Define the default NTP servers using the openSUSE ones.