### PR TITLE
Use NetworkManager always (boo#1172684)

### DIFF
--- a/control/control.Kubic.xml
+++ b/control/control.Kubic.xml
@@ -218,9 +218,7 @@ textdomain="control"
     </partitioning>
 
     <network>
-        <force_static_ip config:type="boolean">false</force_static_ip>
-        <network_manager>never</network_manager>
-        <startmode>auto</startmode>
+        <network_manager>always</network_manager>
         <ipv4_forward config:type="boolean">true</ipv4_forward>
         <ipv6_forward config:type="boolean">true</ipv6_forward>
     </network>

--- a/package/skelcd-control-Kubic.changes
+++ b/package/skelcd-control-Kubic.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Feb 04 09:23:32 UTC 2022 - Richard Brown <rbrown@suse.com>
+
+- Use NetworkManager always (boo#1172684)
+- 20220204
+
+-------------------------------------------------------------------
 Tue Sep  7 10:49:43 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Define default NTP servers for Kubic (bsc#1180699)

--- a/package/skelcd-control-Kubic.spec
+++ b/package/skelcd-control-Kubic.spec
@@ -121,7 +121,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-Kubic
 AutoReqProv:    off
-Version:        20210907
+Version:        20220204
 Release:        0
 Summary:        The Kubic control file needed for installation
 License:        MIT


### PR DESCRIPTION
As with Tumbleweed - Wicked lacks caretaking in Tumbleweed and is just slow to boot.
NetworkManager is good enough also for most common server use cases
in Tumbleweed so let's just use one technology for all roles.

YaST anyway allows to switch to wicked in the proposal screen. So those
who know that they need for advanced cases wicked can still have it.